### PR TITLE
feat: thread per core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ tracing-subscriber = "0.3.17"
 url = "2.3.1"
 webpki-roots = "0.23.0"
 
+[features]
+thread_per_core = []
+
 [profile.bench]
 debug = true
 

--- a/src/io/quic.rs
+++ b/src/io/quic.rs
@@ -168,10 +168,29 @@ pub mod server {
         let state_handle = tokio::spawn(state_actor.run());
 
         let server_config = tls_server_config(config.tls_server_name, config.tls_self_signed)?;
-        let endpoint = bind_server_endpoint(bind_addr, server_config)?;
-        let endpoint_handle = endpoint_actor(endpoint, from_conn_tx);
+        #[cfg(feature = "thread_per_core")]
+        {
+            let mut handles = vec![];
+            let num_threads = (num_cpus::get() - 1).max(1);
+            for _i in 0..num_threads {
+                let from_conn_tx = from_conn_tx.clone();
+                let server_config = server_config.clone();
+                let handle = crate::util::spawn_worker_task(move || async move {
+                    let endpoint = bind_server_endpoint(bind_addr, server_config)?;
+                    endpoint_actor(endpoint, from_conn_tx).await
+                });
+                handles.push(handle);
+            }
+            for handle in handles {
+                handle.await??;
+            }
+        }
+        #[cfg(not(feature = "thread_per_core"))]
+        {
+            let endpoint = bind_server_endpoint(bind_addr, server_config)?;
+            endpoint_actor(endpoint, from_conn_tx).await?;
+        }
 
-        endpoint_handle.await?;
         state_handle.await??;
 
         Ok(())


### PR DESCRIPTION
This adds a `thread_per_core` feature that runs the server in thread-per-core mode. With the feature enabled, the server spawns one thread per CPU core and runs a `current_thread` tokio runtime in each. One thread is used for the server state task loop, the other threads each bind a UDP socket (with `REUSE_PORT` set to true) and run the quinn and conn loops in the single-threaded tokio runtime.

Initial benchmarks are inconclusive. Leaving this here for the time being to be reevaluated and properly tested later on.